### PR TITLE
Make DB and output paths configurable via environment

### DIFF
--- a/helm/all-tickers/templates/deployment.yaml
+++ b/helm/all-tickers/templates/deployment.yaml
@@ -50,6 +50,10 @@ spec:
               value: {{ .Values.env.NODE_OPTIONS | quote }}
             - name: NODE_ENV
               value: {{ .Values.env.NODE_ENV | quote }}
+            - name: DB_PATH
+              value: {{ .Values.persistence.mountPath | quote }}
+            - name: OUTPUT_PATH
+              value: {{ .Values.persistence.mountPath | quote }}
             {{- if .Values.configMap.enabled }}
             - name: PIPELINE_ENABLED
               valueFrom:

--- a/helm/all-tickers/values.yaml
+++ b/helm/all-tickers/values.yaml
@@ -27,6 +27,7 @@ securityContext:
   readOnlyRootFilesystem: false
   runAsNonRoot: true
   runAsUser: 1000
+  runAsGroup: 2000
 
 service:
   type: ClusterIP

--- a/src/db/generate-tickers.js
+++ b/src/db/generate-tickers.js
@@ -3,7 +3,8 @@ const path = require('path');
 
 class TickerGenerator {
     constructor() {
-        this.dbPath = path.join(__dirname, 'tickers.db');
+        // Use mounted volume path for database storage
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
     }
 

--- a/src/export/export-data.js
+++ b/src/export/export-data.js
@@ -4,9 +4,9 @@ const path = require('path');
 
 class DataExporter {
     constructor() {
-        this.dbPath = path.join(__dirname, '../db/ticker_data.db');
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'ticker_data.db');
         this.db = new Database(this.dbPath);
-        this.outputDir = path.join(__dirname, '..', '..', 'output');
+        this.outputDir = process.env.OUTPUT_PATH || '/app/output';
     }
 
     async getAllTickerData() {

--- a/src/export/export-nyse-results.js
+++ b/src/export/export-nyse-results.js
@@ -6,11 +6,11 @@ class NYSEResultsExporter {
     constructor() {
         // NYSE exchanges we want to include
         this.nyseExchanges = ['NYQ', 'NMS', 'NYSE Arca', 'BATS'];
-        this.dbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
-        
+
         // Output paths
-        this.outputDir = path.join(__dirname, '..', '..', 'output');
+        this.outputDir = process.env.OUTPUT_PATH || '/app/output';
         this.nyseTickersPath = path.join(this.outputDir, 'nyse_tickers.json');
         this.nyseTickersCSVPath = path.join(this.outputDir, 'nyse_tickers.csv');
         

--- a/src/export/export-results.js
+++ b/src/export/export-results.js
@@ -4,9 +4,10 @@ const path = require('path');
 
 class TickerExporter {
     constructor() {
-        this.dbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        // Use mounted volume path for database storage
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
-        this.outputDir = path.join(__dirname, '..', '..', 'output'); // Two levels above src/export
+        this.outputDir = process.env.OUTPUT_PATH || '/app/output';
         this.resultsPath = path.join(this.outputDir, 'results.json');
         this.activeTickersPath = path.join(this.outputDir, 'active_tickers.json');
         this.delistedTickersPath = path.join(this.outputDir, 'delisted_tickers.json');

--- a/src/return-data/return-data.js
+++ b/src/return-data/return-data.js
@@ -49,11 +49,11 @@ function hasValidationWarning(ticker) {
 
 class TickerDataDatabase {
     constructor() {
-        const dbPath = path.join(__dirname, '..', 'db', 'ticker_data.db');
+        const dbPath = path.join(process.env.DB_PATH || '/app/output', 'ticker_data.db');
         this.db = new Database(dbPath);
         
         // Also connect to the validation database to mark inactive tickers
-        const validationDbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        const validationDbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.validationDb = new Database(validationDbPath);
         
         this.initializeDatabase();

--- a/src/validate/revalidate-active.js
+++ b/src/validate/revalidate-active.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 class ActiveTickerRevalidator {
     constructor() {
-        this.dbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
         this.concurrentRequests = 8; // Conservative concurrency for active ticker validation
         this.batchSize = 500;

--- a/src/validate/revalidate-inactive.js
+++ b/src/validate/revalidate-inactive.js
@@ -7,7 +7,7 @@ const path = require('path');
 
 class InactiveTickerRevalidator {
     constructor() {
-        this.dbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
         this.concurrentRequests = 10; // Lower concurrency for re-validation
         this.batchSize = 500;

--- a/src/validate/validate-tickers.js
+++ b/src/validate/validate-tickers.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 class FastTickerValidator {
     constructor() {
-        this.dbPath = path.join(__dirname, '..', 'db', 'tickers.db');
+        this.dbPath = path.join(process.env.DB_PATH || '/app/output', 'tickers.db');
         this.db = new sqlite3.Database(this.dbPath);
         this.batchSize = 500; // Increased batch size
         this.delayMs = 200; // Reduced delay


### PR DESCRIPTION
Replaced hardcoded database and output paths with environment variable-based configuration in all relevant modules. Updated Helm deployment and values to set DB_PATH and OUTPUT_PATH from the mounted volume, and added runAsGroup to securityContext. This improves flexibility for deployments using persistent storage.